### PR TITLE
Add no-unused-promise rule

### DIFF
--- a/lib/rules/no-unused-promise.js
+++ b/lib/rules/no-unused-promise.js
@@ -1,0 +1,21 @@
+// Disallow certain method names (specified via settings) known to return
+// promises from being called without doing something with their result.
+
+module.exports = function(context) {
+  var promiseMethodNames = new Set(context.options);
+  return {
+    CallExpression: function (node) {
+      // We only care if the parent of the call expression is an expression statement.
+      // Otherwise, we are doing _something_ with the promise.
+      if (node.parent.type !== 'ExpressionStatement') return;
+
+      // The rule is only relevant if the callee is a member expression
+      if (node.callee.type !== 'MemberExpression') return;
+
+      const property = node.callee.property;
+
+      if (!promiseMethodNames.has(property.name)) return;
+      context.report(node, `Promise returned by "${property.name}" call must be handled`);
+    }
+  };
+};

--- a/tests/lib/rules/no-unused-promise.js
+++ b/tests/lib/rules/no-unused-promise.js
@@ -1,0 +1,46 @@
+const rule = require('../../../lib/rules/no-unused-promise');
+const RuleTester = require("eslint").RuleTester;
+
+const ruleTester = new RuleTester({parserOptions: {ecmaVersion: '2017'}});
+
+const options = ['qsave', 'then', 'fail'];
+
+const makeError = function ([code, methodName]) {
+  return {
+    code,
+    options,
+    errors: [{
+      message: `Promise returned by "${methodName}" call must be handled`,
+    }],
+  }
+}
+
+ruleTester.run('no-unused-promise', rule, {
+  valid: [
+    'let foo = bar',
+    'qsave()',
+    'let x = qsave()',
+    'let blah = qux.qsave().then(function () { return 5; }).done()',
+    `var f = function * () {
+      yield foo.bar.qsave();
+    }`,
+    'let y = model.qsave',
+    `var f = function (model) {
+      return model.qsave();
+    }`,
+  ].map(function (code) {
+    return {code, options};
+  }),
+
+  invalid: [
+    ['foo.qsave()', 'qsave'],
+
+    [`var f = function () {
+      makeModel().then(function (model) {
+        return model.qsave();
+      })
+    }`, 'then'],
+
+    ['var f = function * (model) { model.qsave() }', 'qsave'],
+  ].map(makeError),
+})


### PR DESCRIPTION
Unfortunately, this won't save us with PgModel#save (maybe we should rename that to qsave).

Something I didn't add, but might be a good idea, is a convention based rule, where any method starting with a lowercase `q` followed by a capital letter or a consonant is assumed to return a promise. We use that convention pretty inconsistently right now though.